### PR TITLE
Enables merging of stubs that come after the enable diego ssh stub.

### DIFF
--- a/stubs-for-cf-release/enable_diego_ssh_in_cf.yml
+++ b/stubs-for-cf-release/enable_diego_ssh_in_cf.yml
@@ -1,11 +1,15 @@
 properties:
+  <<: (( merge ))
   app_ssh:
     host_key_fingerprint: a6:d1:08:0b:b0:cb:9b:5f:c4:ba:44:2a:97:26:19:8a
     oauth_client_id: ssh-proxy
   cc:
+    <<: (( merge ))
     allow_app_ssh_access: true
   uaa:
+    <<: (( merge ))
     clients:
+      <<: (( merge ))
       ssh-proxy:
         authorized-grant-types: authorization_code
         autoapprove: true


### PR DESCRIPTION
Currently all stubs merging in after this stub will be butchered for the client fields.
I added extra merge statements in to make sure other properties besides the clients can get merged in as well.

Please look over this and decide if these extra merges are necessary.
